### PR TITLE
PAM userpresence flag

### DIFF
--- a/pam-u2f.c
+++ b/pam-u2f.c
@@ -54,6 +54,8 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t *cfg) {
       cfg->cue = 1;
     if (strcmp(argv[i], "nodetect") == 0)
       cfg->nodetect = 1;
+    if (strcmp(argv[i], "userpresence") == 0)
+      cfg->userpresence = 1;
     if (strncmp(argv[i], "authfile=", 9) == 0)
       cfg->auth_file = argv[i] + 9;
     if (strncmp(argv[i], "authpending_file=", 17) == 0)
@@ -101,6 +103,7 @@ static void parse_cfg(int flags, int argc, const char **argv, cfg_t *cfg) {
     D(cfg->debug_file, "interactive=%d", cfg->interactive);
     D(cfg->debug_file, "cue=%d", cfg->cue);
     D(cfg->debug_file, "nodetect=%d", cfg->nodetect);
+    D(cfg->debug_file, "userpresence=%d", cfg->userpresence);
     D(cfg->debug_file, "manual=%d", cfg->manual);
     D(cfg->debug_file, "nouserok=%d", cfg->nouserok);
     D(cfg->debug_file, "openasuser=%d", cfg->openasuser);

--- a/util.c
+++ b/util.c
@@ -479,7 +479,6 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
   int r;
   int retval = -2;
   int cose_type;
-  int user_presence;
   size_t kh_len;
   size_t ndevs = 0;
   size_t ndevs_prev = 0;
@@ -618,11 +617,6 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
       goto out;
     }
 
-    if (strchr(devices[i].attributes, '+'))
-      user_presence = 1;
-    else
-      user_presence = 0;
-
     fido_assert_set_options(assert, false, false);
 
     if (!random_bytes(challenge, sizeof(challenge))) {
@@ -653,7 +647,7 @@ int do_authentication(const cfg_t *cfg, const device_t *devices,
       for (size_t j = 0; authlist[j] != NULL; j++) {
         fido_assert_set_options(assert, false, false);
         r = fido_dev_get_assert(authlist[j], assert, NULL);
-        if (user_presence) {
+        if (cfg->userpresence) {
           if ((!fido_dev_is_fido2(authlist[j]) &&
               r == FIDO_ERR_USER_PRESENCE_REQUIRED) || r == FIDO_OK) {
             if (cfg->manual == 0 && cfg->cue && !cued) {

--- a/util.h
+++ b/util.h
@@ -39,6 +39,7 @@ typedef struct {
   int interactive;
   int cue;
   int nodetect;
+  int userpresence;
   const char *auth_file;
   const char *authpending_file;
   const char *origin;


### PR DESCRIPTION
Remove per-key user presence configuration and switch to a global PAM module configuration flag.