### PR TITLE
Pamu2fcfg pin support

### DIFF
--- a/pamu2fcfg/cmdline.ggo
+++ b/pamu2fcfg/cmdline.ggo
@@ -9,7 +9,6 @@ option "origin" o "Origin URL to use during registration. Defaults to pam://host
 option "appid" i "Application ID to use during registration. Defaults to pam://hostname" string optional
 option "type" t "COSE type to use during registration (ES256 or RS256). Defaults to ES256." string optional
 option "resident" r "Generate a resident credential" flag off
-option "no-user-presence" N "Allow the credential to be used without ensuring the user's presence" flag off
 option "debug" d "Print debug information (highly verbose)" flag off
 option "verbose" v "Print information about chosen origin and appid" flag off
 groupoption "username" u "The name of the user registering the device. Defaults to the current user name" string group="user"

--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -34,7 +34,6 @@ int main(int argc, char *argv[]) {
   size_t ndevs;
   int cose_type;
   int resident_key;
-  int user_presence;
   int r;
   char *origin = NULL;
   char *appid = NULL;
@@ -166,11 +165,6 @@ int main(int argc, char *argv[]) {
   else
     resident_key = 0;
 
-  if (args_info.no_user_presence_given)
-    user_presence = 0;
-  else
-    user_presence = 1;
-
   r = fido_cred_set_options(cred, resident_key, false);
   if (r != FIDO_OK) {
     fprintf(stderr, "error: fido_cred_set_options (%d) %s\n", r,
@@ -287,9 +281,8 @@ int main(int argc, char *argv[]) {
   if (!args_info.nouser_given)
     printf("%s", user);
 
-  printf(":%s,%s,%s,%s", resident_key ? "*" : b64_kh, b64_pk,
-         cose_type == COSE_ES256 ? "es256" : "rs256",
-         user_presence ? "+" : "-");
+  printf(":%s,%s,%s", resident_key ? "*" : b64_kh, b64_pk,
+         cose_type == COSE_ES256 ? "es256" : "rs256");
 
   exit_code = EXIT_SUCCESS;
 

--- a/pamu2fcfg/pamu2fcfg.c
+++ b/pamu2fcfg/pamu2fcfg.c
@@ -6,6 +6,8 @@
 #define PAM_PREFIX "pam://"
 #define TIMEOUT 15
 #define FREQUENCY 1
+#define MAX_PIN_SIZE_BYTE 255
+#define UTF8_CHAR_MAX_SIZE 4
 
 #include <fido.h>
 
@@ -14,12 +16,45 @@
 #include <string.h>
 #include <getopt.h>
 #include <unistd.h>
+#include <termios.h>
 #include <sys/types.h>
 #include <pwd.h>
 
 #include "b64.h"
 #include "cmdline.h"
 #include "util.h"
+
+/*
+ * From https://stackoverflow.com/q/1196418
+ */
+char *readpassphrase(const char *prompt, char *buf, size_t bufsiz) {
+  struct termios oflags, nflags;
+  char *ret = NULL;
+
+  /* disabling echo */
+  tcgetattr(fileno(stdin), &oflags);
+  nflags = oflags;
+  nflags.c_lflag &= ~ECHO;
+  nflags.c_lflag |= ECHONL;
+
+  if (tcsetattr(fileno(stdin), TCSANOW, &nflags) != 0) {
+      fprintf(stderr, "error: %s: tcsetattr\n", __func__);
+      goto out;
+  }
+
+  printf("%s", prompt);
+  if (fgets(buf, bufsiz, stdin)) {
+    buf[strlen(buf) - 1] = 0;
+    ret = buf;
+  }
+
+out:
+  /* restore terminal */
+  if (tcsetattr(fileno(stdin), TCSANOW, &oflags) != 0)
+      fprintf(stderr, "error: %s: tcsetattr\n", __func__);
+
+  return ret;
+}
 
 int main(int argc, char *argv[]) {
   int exit_code = EXIT_FAILURE;
@@ -38,6 +73,7 @@ int main(int argc, char *argv[]) {
   char *origin = NULL;
   char *appid = NULL;
   char *user = NULL;
+  char *pin = NULL;
   char *b64_kh;
   char *b64_pk;
   struct passwd *passwd;
@@ -232,7 +268,22 @@ int main(int argc, char *argv[]) {
     exit(EXIT_FAILURE);
   }
 
-  r = fido_dev_make_cred(dev, cred, NULL);
+retry:
+  r = fido_dev_make_cred(dev, cred, pin);
+  if (r == FIDO_ERR_PIN_REQUIRED) {
+    pin = malloc(MAX_PIN_SIZE_BYTE);
+    if (!readpassphrase("PIN number: ", pin,
+        (MAX_PIN_SIZE_BYTE-1)/UTF8_CHAR_MAX_SIZE)) {
+      fprintf(stderr, "error: readpassphrase\n");
+      exit(EXIT_FAILURE);
+    }
+    goto retry;
+  }
+  if (pin) {
+    explicit_bzero(pin, MAX_PIN_SIZE_BYTE);
+    free(pin);
+  }
+
   if (r != FIDO_OK) {
     fprintf(stderr, "error: fido_dev_make_cred (%d) %s\n", r, fido_strerr(r));
     exit(EXIT_FAILURE);


### PR DESCRIPTION
The original plan was to use the pam converse() function to read the passphrase but in the case of pamu2fcfg it returns an error, probably because we are not in a pam context and so don't have any pam_handle_t to use.

Instead the next best thing seemed to be from a snippet of a stackoverflow post from which a link has been included to ensure credit to the author.

The passphrase supports the utf8 character set as called in the FIDO 2.0 specification, up to 255 bytes worth of characters. I tested with some funny looking utf8 symbols (one of them being: '☝☔☢☣♒') and it works fine.

The utf8 characters has been considered being up to 4 bytes in size although Yubico seems to consider them as being up to 2 bytes only. Although it seems most of them are up to 2 bytes, the Internet seems to agree they can be up to 4 bytes. This reduces the max PIN length to 63 characters.